### PR TITLE
Fix README header typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Note: `make install-strip` also works. It will exclude debugging symbols.
 
 Here are the relevant `systemd` commands:
 
-#### Serivce install:
+#### Service install:
 ```
 sudo systemctl daemon-reexec
 sudo systemctl enable /usr/lib64/systemd/system/autobrightnesscam.service # May be different on your system.


### PR DESCRIPTION
## Summary
- correct minor typo in README

## Testing
- `./autogen.sh` *(fails: aclocal not found)*
- `sudo apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68838283ee6883228c772ccd4169a54b